### PR TITLE
Feat/message : 중고 상세 페이지 / 마이>쪽지함리스트 => 쪽지보내기 페이지로 이동하기 기능 완성

### DIFF
--- a/src/_typesBundle/productType.ts
+++ b/src/_typesBundle/productType.ts
@@ -45,18 +45,31 @@ interface MessageType {
   sellerId: string;
   buyerId: string;
   createdAt: string;
-  // ex :  messages 메세지 추가돼야함
-  // "messages": [
-  //   {
-  //     "senderId": "buyerId1",
-  //     "content": "안녕하세요, 제품 아직 있나요?",
-  //     "timestamp": 1234567890
-  //   },
-  //   {
-  //     "senderId": "sellerId1",
-  //     "content": "네, 아직 있습니다.",
-  //     "timestamp": 1234567891
-  //   }
-  // ]
+  messages?: MessagesInfoType[];
 }
-export type { UsedProductType, CommentType, SellsItemType, MessageType };
+interface MessagesInfoType {
+  senderId: string;
+  content: string;
+  timestamp: string;
+}
+interface MessageResultType {
+  buyerId: string;
+  createdAt: string;
+  messageId: string;
+  price: number;
+  productId: string;
+  productName: string;
+  productImage: string;
+  quantity: number;
+  seller: UsedProductSellerType;
+  sellerId: string;
+}
+
+export type {
+  UsedProductType,
+  CommentType,
+  SellsItemType,
+  MessageType,
+  MessageResultType,
+  MessagesInfoType,
+};

--- a/src/components/SellerMark.tsx
+++ b/src/components/SellerMark.tsx
@@ -6,7 +6,7 @@ import { Icon_King } from "@/_assets";
 
 // 로그인 유저가 판매자인 경우 Icon생성하기
 // ⭕위치 지정 어디로?
-export const IsSeller = ({ sellerId }: { sellerId: string | null }) => {
+export const SellerMark = ({ sellerId }: { sellerId: string | null }) => {
   const loginUser = useRecoilValue(userState);
   if (sellerId && sellerId == loginUser._id)
     return <img src={Icon_King} className="w-4 m-2 absolute top-0 right-0 " alt="유저가 판매자" />;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,7 +5,7 @@ import { UserProfileInfoComp } from './UserProfileInfoComp';
 import { LoginButton } from './button';
 import { BasicButton } from './button';
 import { BottomNav } from './BottomNav';
-import { IsSeller } from './IsSeller';
+import { SellerMark } from './SellerMark';
 
 export {
   Layout,
@@ -15,5 +15,5 @@ export {
   LoginButton,
   BasicButton,
   BottomNav,
-  IsSeller,
+  SellerMark,
 };

--- a/src/pages/usedMessage/UsedMessage.tsx
+++ b/src/pages/usedMessage/UsedMessage.tsx
@@ -73,6 +73,21 @@ export const UsedMessage = () => {
     });
   };
 
+  // ⭕ 에러 컴포넌트, 로티이미지 추가 : 에러 페이지 데이터 새로고침 해주세요
+  if (isError) {
+    return (
+      <div className='border h-40 p-2 text-center'>
+        <p>데이터를 가져오는 동안 문제가 발생했습니다</p>
+        <button
+          className='cursor-pointer hover:font-bold'
+          onClick={() => window.location.reload()}
+        >
+          GeekChic 메세지 가져오기 새로고침
+        </button>
+      </div>
+    );
+  }
+
   return (
     <Layout title={'쪽지 보내기'}>
       <div className='p-8 min-h-screen flex flex-col bg-gray-100'>
@@ -92,6 +107,7 @@ export const UsedMessage = () => {
           </div>
         </section>
 
+        {/* messages */}
         <section className='w-full flex flex-col'>
           <div>
             {isPending ? (
@@ -120,8 +136,8 @@ export const UsedMessage = () => {
           </div>
         </section>
 
+        {/* 대화 입력창 */}
         <section>
-          {/* 대화 입력창 */}
           <div className='w-[532px] flex items-center fixed bottom-24'>
             <textarea
               className='border w-full p-2 resize-none outline-0'

--- a/src/pages/usedMessage/UsedMessage.tsx
+++ b/src/pages/usedMessage/UsedMessage.tsx
@@ -1,7 +1,16 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
 import { useLocation } from 'react-router-dom';
+
 import { Layout } from '@/components';
+import { userState } from '@/_recoil';
+import { sendMessages, getMessages } from '@/_apis';
+import { MessagesInfoType } from '@/_typesBundle';
 
 export const UsedMessage = () => {
+  const queryClient = useQueryClient();
+  const loginUser = useRecoilValue(userState);
   const location = useLocation();
   const {
     buyerId,
@@ -16,12 +25,59 @@ export const UsedMessage = () => {
     sellerName,
   } = location.state || {};
 
-  console.log(messageId);
+  const [newMessage, setNewMessage] = useState('');
+  const {
+    data: messages,
+    isPending,
+    isError,
+  } = useQuery({
+    queryKey: ['usedMessages', messageId],
+    queryFn: async () => await getMessages(messageId),
+    retry: 3,
+    retryDelay: 1000,
+  });
+
+  interface sendMessagesMutationTypt {
+    currentMessages: MessagesInfoType;
+    messageId: string;
+  }
+  const sendMessagesMutation = useMutation({
+    mutationFn: async ({
+      currentMessages,
+      messageId,
+    }: sendMessagesMutationTypt) => {
+      await sendMessages({ currentMessages, messageId });
+    },
+    onSuccess: () => {
+      setNewMessage('');
+      queryClient.invalidateQueries(
+        {
+          queryKey: ['usedMessages', messageId],
+          refetchType: 'active',
+          exact: true,
+        },
+        { throwOnError: true, cancelRefetch: true },
+      );
+    },
+  });
+
+  const onClickSendMessage = () => {
+    const currentMessages: MessagesInfoType = {
+      senderId: loginUser._id,
+      content: newMessage,
+      timestamp: new Date().toISOString(),
+    };
+    sendMessagesMutation.mutate({
+      currentMessages,
+      messageId: messageId as string,
+    });
+  };
+
   return (
     <Layout title={'쪽지 보내기'}>
       <div className='p-8 min-h-screen flex flex-col bg-gray-100'>
         {/* 판매자정보 */}
-        <div className='border p-4 mb-8 flex bg-white'>
+        <section className='border p-4 mb-8 flex bg-white'>
           <img
             src={productImage}
             alt='Product'
@@ -34,11 +90,58 @@ export const UsedMessage = () => {
               {price.toLocaleString()}원
             </div>
           </div>
-        </div>
+        </section>
 
-        <div className='p-3 mb-4 bg-gray-200 text-black rounded-lg'>
-          "{productName}" 판매자 <br /> {sellerName}입니다
-        </div>
+        <section className='w-full flex flex-col'>
+          <div>
+            {isPending ? (
+              <p>로딩중 ⭕로딩 스켈레톤 적용</p>
+            ) : (
+              messages &&
+              messages.map((message, idx) => {
+                const isLoginUserMessage = message.senderId === loginUser._id;
+                return (
+                  <div
+                    key={idx}
+                    className={`w-3/5 p-3 mb-4 rounded-lg ${
+                      isLoginUserMessage
+                        ? 'ml-auto bg-[#b788e0] text-white text-right'
+                        : 'mr-auto bg-gray-200 text-left'
+                    }`}
+                  >
+                    <div>{message.content}</div>
+                    <div className='text-xs'>
+                      {message.timestamp.split('T')[0]}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </section>
+
+        <section>
+          {/* 대화 입력창 */}
+          <div className='w-[532px] flex items-center fixed bottom-24'>
+            <textarea
+              className='border w-full p-2 resize-none outline-0'
+              value={newMessage}
+              onChange={(e) => setNewMessage(e.target.value)}
+              placeholder='메시지를 입력하세요'
+              // disabled={isSalesCompleted}
+            />
+            <button
+              className='text-white px-4 py-2 rounded bg-[#8F5BBD]'
+              onClick={onClickSendMessage}
+              // className={`text-white px-4 py-2 rounded ${
+              //   isSalesCompleted ? 'bg-gray-400' : 'bg-[#8F5BBD]'
+              // }`}
+              // disabled={isSalesCompleted}
+            >
+              전송
+            </button>
+          </div>
+        </section>
       </div>
     </Layout>
   );

--- a/src/pages/usedMessageList/UsedMessageList.tsx
+++ b/src/pages/usedMessageList/UsedMessageList.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getMessageList, MessageResultType } from '@/_apis';
 import { userState } from '@/_recoil';
-import { Layout, IsSeller } from '@/components';
+import { Layout, SellerMark } from '@/components';
 
 export const UsedMessageList = () => {
   const { listMessages } = useRecoilValue(userState);
@@ -19,7 +19,7 @@ export const UsedMessageList = () => {
     retry: 3,
     retryDelay: 1000,
   });
-  console.log(messagesList);
+
   // ⭕에러 컴포넌트, 로티이미지
   if (isError)
     return (
@@ -38,7 +38,7 @@ export const UsedMessageList = () => {
     );
 
   return (
-    <Layout title='쪽지보내기'>
+    <Layout title='내 쪽지함'>
       {isPending ? (
         <p>로딩중</p>
       ) : (
@@ -91,7 +91,7 @@ export const UsedMessageList = () => {
                         alt='icon'
                         className='w-24 h-24 rounded-full object-cover mr-2 '
                       />
-                      <IsSeller sellerId={message?.seller._id} />
+                      <SellerMark sellerId={message?.seller._id} />
                     </div>
                     <div className='w-4/5 flex justify-between items-start '>
                       <div className='flex flex-col flex-1'>

--- a/src/pages/usedMessageList/UsedMessageList.tsx
+++ b/src/pages/usedMessageList/UsedMessageList.tsx
@@ -80,8 +80,7 @@ export const UsedMessageList = () => {
                       productName,
                       quantity,
                       sellerId,
-                      sellerName : seller.username,
-                      
+                      sellerName : seller.username, 
                     }}
                     className={`flex p-2 items-center hover:bg-[#eee]`}
                   >

--- a/src/pages/usedProductsDetail/UsedProductsDetail.tsx
+++ b/src/pages/usedProductsDetail/UsedProductsDetail.tsx
@@ -42,7 +42,6 @@ export const UsedProductsDetail = () => {
     checkPreviousMessage();
   }, []);
 
-  console.log(previousMessage);
 
   const onClickAddMessage = async () => {
     const messageId = uuidv4();
@@ -58,9 +57,23 @@ export const UsedProductsDetail = () => {
     }
     navigate(
       `/message/send/${previousMessage !== null ? previousMessage.messageId : messageId}`,
+      {
+        state: {
+          buyerId: isLoginUser._id,
+          createdAt: new Date().toISOString(),
+          messageId:
+            previousMessage !== null ? previousMessage.messageId : messageId,
+          price: usedProduct.price,
+          productId: usedProduct.productId,
+          productImage: usedProduct.images[0],
+          productName: usedProduct.productName,
+          quantity: usedProduct.quantity,
+          sellerId: usedProduct.seller._id,
+          sellerName: usedProduct.seller.username,
+        },
+      },
     );
   };
-
   if (isPending) {
     return <Skeleton />;
   }


### PR DESCRIPTION
- 중고 상세페이지와 마이>쪽지함리스트에서 쪽지보내기 페이지로 이동할 때 Link와 navigation을 사용한다.
- 각각의 라우터의 state에 데이터를 넣어 페이지 이동 후, state를 가지고 UI를 렌더링한다.
- 각 페이지에서 오는 state를 통일시켜 페이지 렌더링을 완성시킴