### PR TITLE
Refactoring : home페이지의 자식 컴포넌트의 props을 메모이제이션 및 UI/비즈니스 로직 분리, 중복 컴포넌트 리팩토링

### DIFF
--- a/src/_apis/apis.ts
+++ b/src/_apis/apis.ts
@@ -317,7 +317,8 @@ export const searchProducts = async ({
     console.log(searchQuery, url);
     const snapshot = await get(ref(database, url));
     if (snapshot.exists()) {
-      const dataArr = Object.values(snapshot.val()) as Array<UsedProductType | ProductType>;
+      const dataArr = Object.values(snapshot.val()) as Array<        UsedProductType | ProductType
+      >;
       const filterData = dataArr
         .filter((data) => {
           return (
@@ -341,6 +342,38 @@ export const searchProducts = async ({
     return [];
   } catch (error) {
     console.error('제품 검색 에러', error);
+    return [];
+  }
+};
+
+export const getMainSortData = async ({
+  url,
+  categories,
+}: {
+  url: string;
+  categories: string;
+}): Promise<ProductType[]> => {
+  console.log(url, categories);
+  try {
+    const snapshot = await get(ref(database, `${url}`));
+    if (snapshot.exists()) {
+      let data = Object.values(snapshot.val()) as ProductType[];
+
+      const filterData =
+        categories !== 'all'
+          ? data.filter((item) => item.categories === categories)
+          : data;
+      const sortedData = filterData.sort(
+        (a, b) =>
+          new Date(b.createdAt.join('')).getTime() -
+          new Date(a.createdAt.join('')).getTime(),
+      );
+      console.log(sortedData);
+      return sortedData;
+    }
+    return [];
+  } catch (error) {
+    console.error(error);
     return [];
   }
 };

--- a/src/_typesBundle/productType.ts
+++ b/src/_typesBundle/productType.ts
@@ -9,6 +9,19 @@ interface ProductType {
   quantity: number;
   size: string;
 }
+
+type TabTypes = 'outer' | 'top' | 'bottom' | 'shoes' | 'acc' | 'all';
+export interface CategoriesType {
+  title: string;
+  value: TabTypes;
+}
+export interface CategoriesButtonProps extends CategoriesType {
+  activeTab: TabTypes;
+  setActiveTab: React.Dispatch<
+    React.SetStateAction<'outer' | 'top' | 'bottom' | 'shoes' | 'acc' | 'all'>
+  >;
+}
+
 interface CartItemType {
   cartId: string;
   categories: string;
@@ -65,5 +78,5 @@ export type {
   PaymentsProductItemsType,
   PaymentsDataType,
   PaymentsDataInfoType,
-  CommentType
+  CommentType,
 };

--- a/src/_utils/utils.ts
+++ b/src/_utils/utils.ts
@@ -59,6 +59,14 @@ export const validateComment = (comment: string) => {
   }
 };
 
+export const validateSearchQuery = (searchQuery: string) => {
+  if (searchQuery.length < 1) {
+    return alert('검색어를 입력해주세요');
+  } else {
+    return true;
+  }
+};
+
 export const validateCartItems = (size: string, quantity: number) => {
   if (size === '' || quantity === 0) {
     return alert('구매하시려는 사이즈 또는 수량을 확인해주세요');

--- a/src/components/button/BasicButton.tsx
+++ b/src/components/button/BasicButton.tsx
@@ -1,3 +1,5 @@
+import { memo } from "react";
+
 interface BasicButtonProps {
   onClickFunc: () => void;
   text: string;
@@ -5,7 +7,7 @@ interface BasicButtonProps {
   width?: string;
 }
 
-export const BasicButton = ({
+export const BasicButton = memo(({
   onClickFunc,
   text,
   bg,
@@ -19,4 +21,4 @@ export const BasicButton = ({
       {text}
     </button>
   );
-};
+});

--- a/src/components/searchBar/SearchBar.tsx
+++ b/src/components/searchBar/SearchBar.tsx
@@ -1,47 +1,44 @@
-import { useState } from 'react';
+import { useState, memo } from 'react';
 import { BsSearch } from 'react-icons/bs';
 
 import { searchProducts, SearchResult } from '@/_apis';
+import { validateSearchQuery } from '@/_utils';
 
 interface SearchBarProps {
   url: string;
-  setSearchResult: React.Dispatch<
-    React.SetStateAction<SearchResult[]>
-  >;
+  setSearchResult: React.Dispatch<React.SetStateAction<SearchResult[]>>;
   setIsSearching: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export const SearchBar = ({
-  url,
-  setSearchResult,
-  setIsSearching,
-}: SearchBarProps) => {
-  
-  const [searchQuery, setSearchQuery] = useState('');
+export const SearchBar = memo(
+  ({ url, setSearchResult, setIsSearching }: SearchBarProps) => {
+    const [searchQuery, setSearchQuery] = useState('');
 
-  // ⭕mutation으로 검색기능 구현
-  const onClickButtonSearch = async () => {
-    const result = await searchProducts({ searchQuery, url });
-    setSearchResult(result);
-    setIsSearching(true);
-  };
+    // ⭕mutation으로 검색기능 구현
+    const onClickButtonSearch = async () => {
+      if (!validateSearchQuery(searchQuery)) return;
+      const result = await searchProducts({ searchQuery, url });
+      setSearchResult(result);
+      setIsSearching(true);
+    };
 
-  return (
-    <section className='w-full h-[50px] px-4 mb-8 flex items-center justify-between text-xl bg-[#EEE] rounded-lg'>
-      <input
-        className='w-full outline-none placeholder-gray-500 bg-[#EEE]'
-        type='text'
-        placeholder='상품검색'
-        maxLength={50}
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') onClickButtonSearch();
-        }}
-      />
-      <button onClick={onClickButtonSearch} className='bg-[#EEE] h-full'>
-        <BsSearch />
-      </button>
-    </section>
-  );
-};
+    return (
+      <section className='w-full h-[50px] px-4 mb-8 flex items-center justify-between text-xl bg-[#EEE] rounded-lg'>
+        <input
+          className='w-full outline-none placeholder-gray-500 bg-[#EEE]'
+          type='text'
+          placeholder='상품검색'
+          maxLength={50}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onClickButtonSearch();
+          }}
+        />
+        <button onClick={onClickButtonSearch} className='bg-[#EEE] h-full'>
+          <BsSearch />
+        </button>
+      </section>
+    );
+  },
+);

--- a/src/hooks/useProducts.ts
+++ b/src/hooks/useProducts.ts
@@ -1,0 +1,15 @@
+import { getMainSortData } from '@/_apis';
+import { ProductType } from '@/_typesBundle';
+import { useQuery } from '@tanstack/react-query';
+
+export const useProducts = (activeTab: string) => {
+  return useQuery<ProductType[]>({
+    queryKey: ['products', activeTab],
+    queryFn: async () =>
+      await getMainSortData({
+        url: 'products',
+        categories: activeTab,
+      }),
+    enabled: !!activeTab,
+  });
+};

--- a/src/pages/home/CategoriesButton.tsx
+++ b/src/pages/home/CategoriesButton.tsx
@@ -1,11 +1,5 @@
-interface CategoriesButtonProps {
-  title: string;
-  value: 'outer' | 'top' | 'bottom' | 'shoes' | 'acc' | 'all';
-  activeTab: 'outer' | 'top' | 'bottom' | 'shoes' | 'acc' | 'all';
-  setActiveTab: React.Dispatch<
-    React.SetStateAction<'outer' | 'top' | 'bottom' | 'shoes' | 'acc' | 'all'>
-  >;
-}
+import { CategoriesButtonProps } from "@/_typesBundle";
+
 export const CategoriesButton = ({
   title,
   value,

--- a/src/pages/home/CategoriesButton.tsx
+++ b/src/pages/home/CategoriesButton.tsx
@@ -1,18 +1,15 @@
-import { CategoriesButtonProps } from "@/_typesBundle";
+import { memo } from 'react';
+import { CategoriesButtonProps } from '@/_typesBundle';
 
-export const CategoriesButton = ({
-  title,
-  value,
-  activeTab,
-  setActiveTab,
-}: CategoriesButtonProps) => {
-
-  return (
-    <button
-      onClick={() => setActiveTab(value)}
-      className={`m-3 py-1 px-2 hover:bg-gray-100 ${activeTab === value ? 'text-[#b66cf7] font-bold' : 'text-gray-500'}`}
-    >
-      {title}
-    </button>
-  );
-};
+export const CategoriesButton = memo(
+  ({ title, value, activeTab, setActiveTab }: CategoriesButtonProps) => {
+    return (
+      <button
+        onClick={() => setActiveTab(value)}
+        className={`m-3 py-1 px-2 hover:bg-gray-100 ${activeTab === value ? 'text-[#b66cf7] font-bold' : 'text-gray-500'}`}
+      >
+        {title}
+      </button>
+    );
+  },
+);

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -4,11 +4,11 @@ import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import { CategoriesButton, ProductCard } from './index';
-import { BasicButton, SearchBar,SearchList } from '@/components';
+import { BasicButton, SearchBar, SearchList } from '@/components';
 import { userState } from '@/_recoil';
 import { ProductType } from '@/_typesBundle';
 import { headerLogo, mainImg } from '@/_assets';
-import { getUsedPageSortData, SearchResult } from '@/_apis';
+import { getMainSortData, SearchResult } from '@/_apis';
 
 export const Home = () => {
   const user = useRecoilValue(userState);
@@ -22,9 +22,13 @@ export const Home = () => {
   >('all');
 
   const { data: products, isPending } = useQuery<ProductType[]>({
-    queryKey: ['products'],
+    queryKey: ['products', activeTab],
     queryFn: async () =>
-      await getUsedPageSortData<ProductType>({ url: 'products' }),
+      await getMainSortData({
+        url: 'products',
+        categories: activeTab,
+      }),
+    enabled: !!activeTab,
   });
 
   const onClickMoveProductUpload = () => {
@@ -94,7 +98,7 @@ export const Home = () => {
                 setActiveTab={setActiveTab}
               />
               <CategoriesButton
-                title='가방'
+                title='신발'
                 value='shoes'
                 activeTab={activeTab}
                 setActiveTab={setActiveTab}
@@ -109,6 +113,8 @@ export const Home = () => {
             <section className=''>
               {isPending ? (
                 <p>로딩중</p>
+              ) : products && products.length === 0 ? (
+                <p>데이터가 없습니다</p>
               ) : (
                 <div className='grid grid-cols-4 gap-4 mt-4 mb-24'>
                   {products &&

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,14 +1,14 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import { CategoriesButton, ProductCard } from './index';
 import { BasicButton, SearchBar, SearchList } from '@/components';
+import { useProducts } from '@/hooks/useProducts';
 import { userState } from '@/_recoil';
 import { CategoriesType, ProductType } from '@/_typesBundle';
 import { headerLogo, mainImg } from '@/_assets';
-import { getMainSortData, SearchResult } from '@/_apis';
+import { SearchResult } from '@/_apis';
 
 export const Home = () => {
   const user = useRecoilValue(userState);
@@ -16,7 +16,6 @@ export const Home = () => {
 
   const [searchResult, setSearchResult] = useState<SearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
-
   const [activeTab, setActiveTab] = useState<
     'outer' | 'top' | 'bottom' | 'shoes' | 'acc' | 'all'
   >('all');
@@ -30,36 +29,22 @@ export const Home = () => {
     { title: '악세사리', value: 'acc' },
   ];
 
-  const { data: products, isPending } = useQuery<ProductType[]>({
-    queryKey: ['products', activeTab],
-    queryFn: async () =>
-      await getMainSortData({
-        url: 'products',
-        categories: activeTab,
-      }),
-    enabled: !!activeTab,
-  });
-
-  const onClickMoveProductUpload = () => {
-    navigate('/products/new');
-  };
+  const { data: products, isPending } = useProducts(activeTab);
 
   return (
     <div className='relative'>
-      {user.isAdmin && (
-        <div className='absolute top-8 right-8'>
-          <BasicButton
-            onClickFunc={onClickMoveProductUpload}
-            text='제품등록'
-            bg='bg-black'
-            width='w-[100px]'
-          />
-        </div>
-      )}
       <header className='pt-20 px-8 pb-8 flex flex-col items-center border'>
+        {user.isAdmin && (
+          <div className='absolute top-8 right-8'>
+            <BasicButton
+              onClickFunc={() => navigate('/products/new')}
+              text='제품등록'
+              bg='bg-black'
+              width='w-[100px]'
+            />
+          </div>
+        )}
         <img src={headerLogo} width={'300px'} className='mb-4' />
-
-        {/* 검색바 */}
         <SearchBar
           url='products'
           setSearchResult={setSearchResult}
@@ -93,7 +78,7 @@ export const Home = () => {
               ))}
             </section>
 
-            <section className=''>
+            <section>
               {isPending ? (
                 <p>로딩중</p>
               ) : products && products.length === 0 ? (

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -6,7 +6,7 @@ import { useRecoilValue } from 'recoil';
 import { CategoriesButton, ProductCard } from './index';
 import { BasicButton, SearchBar, SearchList } from '@/components';
 import { userState } from '@/_recoil';
-import { ProductType } from '@/_typesBundle';
+import { CategoriesType, ProductType } from '@/_typesBundle';
 import { headerLogo, mainImg } from '@/_assets';
 import { getMainSortData, SearchResult } from '@/_apis';
 
@@ -20,6 +20,15 @@ export const Home = () => {
   const [activeTab, setActiveTab] = useState<
     'outer' | 'top' | 'bottom' | 'shoes' | 'acc' | 'all'
   >('all');
+
+  const categories: CategoriesType[] = [
+    { title: '전체', value: 'all' },
+    { title: '아우터', value: 'outer' },
+    { title: '상의', value: 'top' },
+    { title: '하의', value: 'bottom' },
+    { title: '신발', value: 'shoes' },
+    { title: '악세사리', value: 'acc' },
+  ];
 
   const { data: products, isPending } = useQuery<ProductType[]>({
     queryKey: ['products', activeTab],
@@ -73,43 +82,17 @@ export const Home = () => {
           </article>
           <article className='p-8'>
             <section className='flex justify-between border-b mb-8'>
-              <CategoriesButton
-                title='전체'
-                value='all'
-                activeTab={activeTab}
-                setActiveTab={setActiveTab}
-              />
-              <CategoriesButton
-                title='아우터'
-                value='outer'
-                activeTab={activeTab}
-                setActiveTab={setActiveTab}
-              />
-              <CategoriesButton
-                title='상의'
-                value='top'
-                activeTab={activeTab}
-                setActiveTab={setActiveTab}
-              />
-              <CategoriesButton
-                title='하의'
-                value='bottom'
-                activeTab={activeTab}
-                setActiveTab={setActiveTab}
-              />
-              <CategoriesButton
-                title='신발'
-                value='shoes'
-                activeTab={activeTab}
-                setActiveTab={setActiveTab}
-              />
-              <CategoriesButton
-                title='악세사리'
-                value='acc'
-                activeTab={activeTab}
-                setActiveTab={setActiveTab}
-              />
+              {categories.map((category) => (
+                <CategoriesButton
+                  key={category.value}
+                  title={category.title}
+                  value={category.value}
+                  activeTab={activeTab}
+                  setActiveTab={setActiveTab}
+                />
+              ))}
             </section>
+
             <section className=''>
               {isPending ? (
                 <p>로딩중</p>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
@@ -20,14 +20,19 @@ export const Home = () => {
     'outer' | 'top' | 'bottom' | 'shoes' | 'acc' | 'all'
   >('all');
 
-  const categories: CategoriesType[] = [
-    { title: '전체', value: 'all' },
-    { title: '아우터', value: 'outer' },
-    { title: '상의', value: 'top' },
-    { title: '하의', value: 'bottom' },
-    { title: '신발', value: 'shoes' },
-    { title: '악세사리', value: 'acc' },
-  ];
+  const categories: CategoriesType[] = useMemo(() => 
+    [
+      { title: '전체', value: 'all' },
+      { title: '아우터', value: 'outer' },
+      { title: '상의', value: 'top' },
+      { title: '하의', value: 'bottom' },
+      { title: '신발', value: 'shoes' },
+      { title: '악세사리', value: 'acc' },
+    ], []);
+
+  const onClickMoveProductUpload = useCallback(() => {
+    navigate('/products/new');
+  }, [navigate]);
 
   const { data: products, isPending } = useProducts(activeTab);
 
@@ -37,7 +42,7 @@ export const Home = () => {
         {user.isAdmin && (
           <div className='absolute top-8 right-8'>
             <BasicButton
-              onClickFunc={() => navigate('/products/new')}
+              onClickFunc={onClickMoveProductUpload}
               text='제품등록'
               bg='bg-black'
               width='w-[100px]'

--- a/src/pages/usedHome/index.ts
+++ b/src/pages/usedHome/index.ts
@@ -1,7 +1,5 @@
 import { UsedHome } from './UsedHome';
-import { SearchBar } from './SearchBar';
-import { SearchList } from './SearchList';
 import { Skeleton } from './Skeleton';
 
-export { SearchBar, SearchList, Skeleton };
+export { Skeleton };
 export default UsedHome;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -26,12 +26,13 @@
       "@/*": ["src/*"],
       "@/pages/*": ["src/pages/*"],
       "@/components/*": ["src/components/*"],
+      "@/hooks/*": ["src/hooks/*"],
       "@/_assets/*": ["src/_assets/*"],
       "@/_apis/*": ["src/_apis/*"],
       "@/_example/*": ["src/_example/*"],
       "@/_utils/*": ["src/_utils/*"],
       "@/_recoil/*": ["src/_recoil/*"],
-      "@/_typesBundle/*": ["src/_typesBundle/*"]
+      "@/_typesBundle/*": ["src/_typesBundle/*"],
     }
   },
   "include": ["src"]

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -24,12 +24,13 @@
       "@/*": ["src/*"],
       "@/pages/*": ["src/pages/*"],
       "@/components/*": ["src/components/*"],
+      "@/hooks/*": ["src/hooks/*"],
       "@/_assets/*": ["src/_assets/*"],
       "@/_apis/*": ["src/_apis/*"],
       "@/_example/*": ["src/_example/*"],
       "@/_utils/*": ["src/_utils/*"],
       "@/_recoil/*": ["src/_recoil/*"],
-      "@/_typesBundle/*": ["src/_typesBundle/*"]
+      "@/_typesBundle/*": ["src/_typesBundle/*"],
     }
   },
   "include": ["vite.config.ts"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       { find: '@/', replacement: '/src' },
       { find: '@/pages', replacement: '/src/pages' },
       { find: '@/components', replacement: '/src/components' },
+      { find: '@/hooks', replacement: '/src/hooks' },
       { find: '@/_assets', replacement: '/src/_assets' },
       { find: '@/_utils', replacement: '/src/_utils' },
       { find: '@/_example', replacement: '/src/_example' },


### PR DESCRIPTION
- home리팩토링
- 자식 컴포넌트가 받는 props의 값과 함수를 메모이제이션 (useMemo, useCallback)
- 해당 컴포넌트를 memo API를 사용해 메모이제이션
- 카테고리 탭의 컴포넌트 반복 코드를 map을 사용해 리팩토링
- query를 사용하는 코드 hooks을 생성하여 비즈니스로직 UI로직 분리