### PR TITLE
Refactoring : 상세페이지 메모이제이션 -> button, comment : memo 및 useCallback사용

### DIFF
--- a/src/components/comment/CommentInput.tsx
+++ b/src/components/comment/CommentInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { useParams } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -8,60 +8,62 @@ import { userState } from '@/_recoil';
 import { CommentType } from '@/_typesBundle';
 import { utcToKoreaTimes, validateComment } from '@/_utils';
 
-export const CommentInput = ({ url, queryKeys }: { url: string; queryKeys: string }) => {
-  const { productId } = useParams<{ productId: string }>();
-  const user = useRecoilValue(userState);
-  const [newComment, setNewComment] = useState('');
-  const queryClient = useQueryClient();
+export const CommentInput = memo(
+  ({ url, queryKeys }: { url: string; queryKeys: string }) => {
+    const { productId } = useParams<{ productId: string }>();
+    const user = useRecoilValue(userState);
+    const [newComment, setNewComment] = useState('');
+    const queryClient = useQueryClient();
 
-  const addCommentMutation = useMutation({
-    mutationFn: async ({ comment }: { comment: CommentType }) => {
-      await addComment({ url, comment });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries(
-        {
-          queryKey: [queryKeys, productId],
-          refetchType: 'active',
-          exact: true,
-        },
-        { throwOnError: true, cancelRefetch: true },
-      );
-    },
-  });
+    const addCommentMutation = useMutation({
+      mutationFn: async ({ comment }: { comment: CommentType }) => {
+        await addComment({ url, comment });
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries(
+          {
+            queryKey: [queryKeys, productId],
+            refetchType: 'active',
+            exact: true,
+          },
+          { throwOnError: true, cancelRefetch: true },
+        );
+      },
+    });
 
-  const onClickAddComment = () => {
-    if (!validateComment(newComment)) return;
+    const onClickAddComment = () => {
+      if (!validateComment(newComment)) return;
 
-    const newCommentData: CommentType = {
-      userId: user._id,
-      username: user.username,
-      avatar: user.avatar,
-      comment: newComment,
-      createdAt: utcToKoreaTimes(),
+      const newCommentData: CommentType = {
+        userId: user._id,
+        username: user.username,
+        avatar: user.avatar,
+        comment: newComment,
+        createdAt: utcToKoreaTimes(),
+      };
+      addCommentMutation.mutate({ comment: newCommentData });
+      setNewComment('');
     };
-    addCommentMutation.mutate({ comment: newCommentData });
-    setNewComment('');
-  };
 
-  return (
-    <section className='w-[535px] h-[120px] mb-10 fixed bottom-0 bg-white'>
-      <div className='flex mt-4 h-[50px]'>
-        <input
-          type='text'
-          className='h-[100%] flex-1 px-4 border rounded-l-md outline-none'
-          placeholder='댓글을 입력하세요'
-          value={newComment}
-          onChange={(e) => setNewComment(e.target.value)}
-        />
+    return (
+      <section className='w-[535px] h-[120px] mb-10 fixed bottom-0 bg-white'>
+        <div className='flex mt-4 h-[50px]'>
+          <input
+            type='text'
+            className='h-[100%] flex-1 px-4 border rounded-l-md outline-none'
+            placeholder='댓글을 입력하세요'
+            value={newComment}
+            onChange={(e) => setNewComment(e.target.value)}
+          />
 
-        <button
-          onClick={onClickAddComment}
-          className='px-4 py-2 bg-[#8F5BBD] text-white rounded-r-md'
-        >
-          댓글 추가
-        </button>
-      </div>
-    </section>
-  );
-};
+          <button
+            onClick={onClickAddComment}
+            className='px-4 py-2 bg-[#8F5BBD] text-white rounded-r-md'
+          >
+            댓글 추가
+          </button>
+        </div>
+      </section>
+    );
+  },
+);

--- a/src/components/comment/CommentsList.tsx
+++ b/src/components/comment/CommentsList.tsx
@@ -6,48 +6,45 @@ import { Comment } from './index';
 import { getTimeSortedData } from '@/_apis';
 import { CommentType } from '@/_typesBundle';
 import { ErrorPageReload } from '@/components';
+import { memo } from 'react';
 
-export const CommentsList = ({
-  url,
-  queryKeys,
-}: {
-  url: string;
-  queryKeys: string;
-}) => {
-  const { productId } = useParams<string>();
+export const CommentsList = memo(
+  ({ url, queryKeys }: { url: string; queryKeys: string }) => {
+    const { productId } = useParams<string>();
 
-  const {
-    data: comments,
-    isPending,
-    isError,
-  } = useQuery<CommentType[]>({
-    queryKey: [queryKeys, productId],
-    queryFn: () => getTimeSortedData<CommentType>({ url: `${url}` }),
-  });
+    const {
+      data: comments,
+      isPending,
+      isError,
+    } = useQuery<CommentType[]>({
+      queryKey: [queryKeys, productId],
+      queryFn: () => getTimeSortedData<CommentType>({ url: `${url}` }),
+    });
 
-  if (isPending) return <p>로딩중... </p>;
-  if (isError) {
+    if (isPending) return <p>로딩중... </p>;
+    if (isError) {
+      return (
+        <ErrorPageReload
+          content='댓글을 가져오는 동안 문제가 발생했습니다'
+          pageName={'제품 상세 페이지'}
+        />
+      );
+    }
     return (
-      <ErrorPageReload
-        content='댓글을 가져오는 동안 문제가 발생했습니다'
-        pageName={'제품 상세 페이지'}
-      />
+      <section className='mb-40'>
+        <div className='text-lg font-bold mb-4'>댓글 {comments.length}</div>
+        {comments.map((comment: CommentType) => {
+          return (
+            <Comment
+              key={comment.commentId}
+              comment={comment}
+              productId={productId as string}
+              queryKeys={queryKeys}
+              url={url}
+            />
+          );
+        })}
+      </section>
     );
-  }
-  return (
-    <section className='mb-40'>
-      <div className='text-lg font-bold mb-4'>댓글 {comments.length}</div>
-      {comments.map((comment: CommentType) => {
-        return (
-          <Comment
-            key={comment.commentId}
-            comment={comment}
-            productId={productId as string}
-            queryKeys={queryKeys}
-            url={url}
-          />
-        );
-      })}
-    </section>
-  );
-};
+  },
+);

--- a/src/pages/productsDetail/ProductsDetail.tsx
+++ b/src/pages/productsDetail/ProductsDetail.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { v4 as uuidv4 } from 'uuid';
@@ -48,7 +48,7 @@ export const ProductsDetail = () => {
       }),
   });
 
-  const sizeOptions = product?.size.split(' / ');
+  const sizeOptions = useMemo(() => product?.size.split(' / '), [product]);
 
   const wishProductMutation = useMutation({
     mutationFn: async () => {
@@ -77,11 +77,11 @@ export const ProductsDetail = () => {
       );
     },
   });
-  const onClickWishProduct = async () => {
+  const onClickWishProduct = () => {
     wishProductMutation.mutate();
   };
 
-  const onClickAddCart = async () => {
+  const onClickAddCart = useCallback(async () => {
     if (!validateCartItems(selectedSize, selectedQuantity)) return;
     const cartItems = {
       productId: productId as string,
@@ -103,8 +103,9 @@ export const ProductsDetail = () => {
       console.error('장바구니 추가 중 에러가 발생했습니다', error);
       alert('오류가 발생했습니다. 나중에 다시 시도해 주세요.');
     }
-  };
-  const onClickPurchaseProduct = () => {
+  }, [selectedSize, selectedQuantity, navigate, productId, setUser, user]);
+
+  const onClickPurchaseProduct = useCallback(() => {
     if (!validateCartItems(selectedSize, selectedQuantity)) return;
     const paymentsId = uuidv4();
     const paymentsData = {
@@ -126,7 +127,17 @@ export const ProductsDetail = () => {
     navigate(`/payments/${paymentsId}`, {
       state: { paymentsData, from: `/products/detail/${product?.id}` },
     });
-  };
+  }, [selectedSize, selectedQuantity, navigate, productId, setUser, user]);
+
+  const commentsUrl = `comments/${productId}`;
+  const queryKeys = 'commentsData';
+
+  const handleSizeChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedSize(e.target.value);
+    },
+    [],
+  );
 
   if (isPending && currentWishPending) {
     return <p>로딩중</p>;
@@ -140,6 +151,7 @@ export const ProductsDetail = () => {
       >
         <img src={Icon_Chevron_left} alt='이전 페이지로' className='w-full' />
       </button>
+      
       {/* image view*/}
       <section className='w-full h-[100%]'>
         <div className='mb-6 bg-gray-200 border-red-400'>
@@ -190,9 +202,7 @@ export const ProductsDetail = () => {
           <select
             id='sizeSelect'
             value={selectedSize}
-            onChange={(e) => {
-              setSelectedSize(e.target.value);
-            }}
+            onChange={handleSizeChange}
             className='block w-full p-3 bg-gray-100 border border-gray-300 text-gray-900 text-m rounded-lg '
           >
             <option value=''>사이즈를 선택하세요</option>
@@ -237,10 +247,9 @@ export const ProductsDetail = () => {
         </div>
       </section>
 
-      {/* comment  */}
       <section className='p-8'>
-        <CommentsList url={`comments/${productId}`} queryKeys={'commentsData'}/>
-        <CommentInput url={`comments/${productId}`} queryKeys={'commentsData'} />
+        <CommentsList url={commentsUrl} queryKeys={queryKeys} />
+        <CommentInput url={commentsUrl} queryKeys={queryKeys} />
       </section>
     </main>
   );


### PR DESCRIPTION
- 장바구니, 바로구매 버튼 컴포넌트를 memo api로 감쌌기 때문에 반은 메모이제이션이 되어있다. detail컴포넌트에서 버튼 컴포넌트에 함수가 props으로 전달되고 있으므로 detail 페이지가 리렌더링 되면 해당 버튼 컴포넌트 또한 함수가 재생성되어 리렌더링 된다. 이를 방지하기 위해 함수에 변동이 없는 경우 캐시된 데이터를 사용할 수 있도록 button컴포넌트의 props으로 전달되는 함수에 useCallback으로 감싸주었다.

- detail컴포넌트에 comment list와 input컴포넌트가 있다. 자식 컴포넌트인 ComemntList와 Input은 부모 컴포넌트가 리렌더링 되어도 본인들에게 전달되는 props에 변경사항이 없으면 리렌더링 되지 않도록 memo API를 통해서 메모이제이션 해 놓았다.
- comment로 전달되는 props의 값들은 string(원시값)이기 때문에 리렌더링 되지 않아 굳이 메모이제이션 하지 않고 전달하였다.